### PR TITLE
fixed bug of keeping the old payload hash

### DIFF
--- a/hawk/server.py
+++ b/hawk/server.py
@@ -149,8 +149,7 @@ class Server(object):
         h_artifacts = copy.copy(artifacts)
         del h_artifacts['mac']
 
-        if 'hash' in options:
-            h_artifacts['hash'] = options['hash']
+        h_artifacts['hash'] = options.get('hash', None)
 
         if 'ext' in options:
             h_artifacts['ext'] = options['ext']


### PR DESCRIPTION
payload hash of the response header is always equal to the request payload hash - even if the payload of the response is different.
