### PR TITLE
Handle the version in setup.py

### DIFF
--- a/hawk/__init__.py
+++ b/hawk/__init__.py
@@ -9,8 +9,10 @@ Python library for HAWK
 
 """
 
+import pkg_resources
+
 __title__ = 'pyhawk'
-__version__ = '0.1.0'
+__version__ = pkg_resources.get_distribution(__title__).version
 __build__ = 0x010200
 __copyright__ = 'Copyright 2013 Mozilla'
 

--- a/setup.py
+++ b/setup.py
@@ -2,28 +2,18 @@
 
 import codecs
 import os
-import re
 from setuptools import setup
 
 
 def read(*parts):
     return codecs.open(os.path.join(os.path.dirname(__file__), *parts)).read()
 
-def find_version(*file_paths):
-    version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
-
-
 README = read('README.rst')
 CHANGELOG = read('CHANGES.txt')
 
 setup(
     name="PyHawk",
-    version=find_version('hawk/__init__.py'),
+    version="0.1.0",
     url='https://github.com/mozilla/PyHawk',
     author='Austin King',
     author_email='ozten@mozilla.com',


### PR DESCRIPTION
and use pkg_resources to get the installed version in the project itself.

I recently discovered about this pkg_resources utility. Thay may be better than having to parse a source file and use regexps to get things right?

ping @peterbe since you proposed the find_version hack in the first place
