### PR TITLE
Use os.urandom() instead of PyCrypto's Crypto.Random.new()

### DIFF
--- a/hawk/hcrypto.py
+++ b/hawk/hcrypto.py
@@ -9,14 +9,10 @@ import hashlib
 import hmac
 import string
 
-from Crypto import Random
-
 from hawk.util import HawkException
 
 
 HAWK_VER = 1
-
-rng = Random.new()
 
 class UnknownAlgorithm(HawkException):
     """Exception raised for bad configuration of algorithm."""
@@ -112,7 +108,9 @@ def calculate_ts_mac(ts, credentials):
 
 def random_string(length):
     """Generates a random string for a given length."""
-    return urlsafe_b64encode(rng.read(length*6))[0:length]
+    # this conservatively gets 8*length bits and then returns 6*length of
+    # them. Grabbing (6/8)*length bits could lose some entropy off the ends.
+    return urlsafe_b64encode(os.urandom(length))[:length]
 
 
 def calculate_bewit(credentials, artifacts, exp):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=README + '\n' + CHANGELOG,
     packages=['hawk', ],
     include_package_data=True,
-    install_requires=['requests>=1.2.0', 'pycrypto==2.6'],
+    install_requires=['requests>=1.2.0'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Yay fewer dependencies.

The `random` module should never be used for crypto, but `os.urandom` is just fine, and pulling in all of PyCrypto for just the RNG is overkill.
