### PR TITLE
Change how 'dlg' is used to create normalized stings.

### DIFF
--- a/hawk/hcrypto.py
+++ b/hawk/hcrypto.py
@@ -72,7 +72,7 @@ def normalize_string(mac_type, options):
     if 'app' in options and options['app'] is not None and \
        len(options['app']) > 0:
         normalized += options['app'] + '\n'
-        if 'dlg' in options and len(options['dlg']) > 0:
+        if 'dlg' in options and options['dlg'] is not None:
             normalized += options['dlg'] + '\n'
 
     return normalized


### PR DESCRIPTION
If options['dlg'] is an empty string, create a blank line in the normalized string for 'dlg' instead of leaving it out entirely.
