### PR TITLE
fix indentation in the get_bewit function

### DIFF
--- a/hawk/client.py
+++ b/hawk/client.py
@@ -275,17 +275,17 @@ def get_bewit(uri, options=None):
     if len(url_parts['query']) > 0:
         resource += '?' + url_parts['query']
 
-        artifacts = {
-            'ts': int(exp),
-            'nonce': '',
-            'method': 'GET',
-            'resource': resource,
-            'host': url_parts['hostname'],
-            'port': str(url_parts['port']),
-            'ext': options['ext']
-            }
+    artifacts = {
+        'ts': int(exp),
+        'nonce': '',
+        'method': 'GET',
+        'resource': resource,
+        'host': url_parts['hostname'],
+        'port': str(url_parts['port']),
+        'ext': options['ext']
+        }
 
-        return hcrypto.calculate_bewit(creds, artifacts, exp)
+    return hcrypto.calculate_bewit(creds, artifacts, exp)
 
 
 def valid_bewit_args(uri, options):


### PR DESCRIPTION
As the code is currently written, it's impossible to generate a bewit for a URL unless
that URL has a query string.  This restriction does not exist in the canonical implementation

https://github.com/hueniverse/hawk/blob/7b050d7920c52d1bb4b5ff815c41d60766a2a108/lib/client.js#L229

I have URLs that I wish to generate a bewit for which do not have query strings.  I guess
I could add a bogus ?a=1 query string to the URI, but it looks more likely that the
indentation for this block of code is one level too many.
